### PR TITLE
Add possibility to use configured API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ $api = API\Factory::make(
     '<email>'
 );
 ```
+ * account: set your account ID (can be found in your dashboard URL or when in a DNS zone)
+ * apiKey: use your Global API key, together with your email address, or use 'api_token' as the email and use a configured API Token.
+ * email: set your login email in combination with your Global API key, or set as 'api_token' combined with a configured API Token.
 
 Get List of streams:
 

--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -34,6 +34,12 @@ class Auth
 
     public function getHeaders()
     {
+        if ($this->getEmail() === 'api_token') {
+            return [
+                'Authorization' => 'Bearer ' . $this->apiKey,
+            ];
+        }
+
         return [
             'X-Auth-Email' => $this->getEmail(),
             'X-Auth-Key' => $this->getApiKey(),


### PR DESCRIPTION
Hello,

this simple pull request allows the use by using a configure API token instead of the Global API Key.

This is more secure: if the api key gets compromised, no access to general cloudflare is possible, only to the allowed actions (Stream).

Also added a bit of documentation around this.

Let me know if you'd need any changes to the PR, or if you're not considering contributions at the time.


Thank you for the work you already put in creating this Repo!